### PR TITLE
Changing max length to 120 to match jshint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2725,7 +2725,7 @@ Unit testing helps maintain clean code, as such I included some of my recommenda
         "requireOperatorBeforeLineBreak": true,
         "requireCamelCaseOrUpperCaseIdentifiers": true,
         "maximumLineLength": {
-          "value": 100,
+          "value": 120,
           "allowComments": true,
           "allowRegex": true
         },


### PR DESCRIPTION
there is a descrepency in how jscs and jshint handle max line length.  Matching the two now.